### PR TITLE
Minor bugfixes

### DIFF
--- a/buffer_parsing.go
+++ b/buffer_parsing.go
@@ -98,7 +98,7 @@ func (buf *Buffer) NumberParse(numType uint8, maxSize int) (int64, error) {
 	var num int64
 	switch maxSize {
 	case TYPE_NUMBER_8:
-		num = int64(np[0])
+		num = int64(int8(np[0]))
 	case TYPE_NUMBER_16:
 		num = int64(int16(binary.BigEndian.Uint16(np)))
 	case TYPE_NUMBER_32:

--- a/msg_getlistresponse.go
+++ b/msg_getlistresponse.go
@@ -30,10 +30,7 @@ func (le *ListEntry) ObjectName() string {
 }
 
 func (le *ListEntry) Scaler() float64 {
-	scaler := 1
-	if le.scaler != 0 {
-		scaler = int(le.scaler)
-	}
+	scaler := int(le.scaler)
 	return math.Pow10(scaler)
 }
 


### PR DESCRIPTION
While using this library I ran into 2 problems with my smartmeter:

1. incorrect handeling of negative numbers
2. incorrect scaling of values with scale 0

using sml_server from libsml the data is correctly parsed:
```
1-0:1.8.0*255#21573.3#Wh
1-0:2.8.0*255#1330.9#Wh
1-0:16.7.0*255#1094#W
1-0:31.7.0*255#0.53#A
1-0:51.7.0*255#4.92#A
1-0:71.7.0*255#0.99#A
1-0:32.7.0*255#230.8#V
1-0:52.7.0*255#229.8#V
1-0:72.7.0*255#231.0#V
1-0:36.7.0*255#23#W
1-0:56.7.0*255#1122#W
1-0:76.7.0*255#-52#W
```

Here is the output of the emmon tool without this pr
```
1-0:1.8.0*255      21573.3
1-0:2.8.0*255       1330.9
1-0:16.7.0*255      10940.0 #<---- incorrect scaling
1-0:31.7.0*255          0.5
1-0:51.7.0*255          4.9
1-0:71.7.0*255          1.0
1-0:32.7.0*255        230.8
1-0:52.7.0*255        229.8
1-0:72.7.0*255        231.0
1-0:36.7.0*255        230.0  #<--- incorrect scaling
1-0:56.7.0*255      11220.0  #<--- incorrect scaling
1-0:76.7.0*255       2040.0  #<--- incorrect scaling and negativ number handeling
```

With this PR applied the output looks like this:
```
1-0:1.8.0*255      21573.3
1-0:2.8.0*255       1330.9
1-0:16.7.0*255       1094.0  #<--- ok
1-0:31.7.0*255          0.5
1-0:51.7.0*255          4.9
1-0:71.7.0*255          1.0
1-0:32.7.0*255        230.8
1-0:52.7.0*255        229.8
1-0:72.7.0*255        231.0
1-0:36.7.0*255         23.0  #<--- ok
1-0:56.7.0*255       1122.0  #<--- ok
1-0:76.7.0*255        -52.0  #<--- ok
```